### PR TITLE
Provider粒度などをリファクタ

### DIFF
--- a/test/feature/feed/feed_repository_test.dart
+++ b/test/feature/feed/feed_repository_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_feed_viewer/feature/feed/feed_repository.dart';
 import 'package:flutter_feed_viewer/local/shared_preferences.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:metadata_fetch/metadata_fetch.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,18 +19,6 @@ class MockResponse extends Mock implements Response {
     final mockResponse = MockResponse._();
     when(mockResponse.data).thenReturn(data);
     return mockResponse;
-  }
-}
-
-class MockMetadata extends Mock implements Metadata {
-  MockMetadata._();
-
-  factory MockMetadata({
-    required String imageUrl,
-  }) {
-    final mockMetadata = MockMetadata._();
-    when(mockMetadata.image).thenReturn(imageUrl);
-    return mockMetadata;
   }
 }
 
@@ -154,19 +141,11 @@ void main() {
             ],
           ),
         ),
-        metadataProviderFamily(testNewArticleUrl).overrideWithValue(
-          Future.value(
-            MockMetadata(
-              imageUrl: testNewArticleImageUrl,
-            ),
-          ),
+        ogpImageUrlProviderFamily(testNewArticleUrl).overrideWith(
+          (ref) => testNewArticleImageUrl,
         ),
-        metadataProviderFamily(testOldArticleUrl).overrideWithValue(
-          Future.value(
-            MockMetadata(
-              imageUrl: testOldArticleImageUrl,
-            ),
-          ),
+        ogpImageUrlProviderFamily(testOldArticleUrl).overrideWith(
+          (ref) => testOldArticleImageUrl,
         ),
         rfc822ParserProvider.overrideWithValue(
           (_) => testFeedUpdatedAt,
@@ -228,19 +207,11 @@ void main() {
             updatedAt: testFeedUpdatedAt,
           ),
         ),
-        metadataProviderFamily(testNewArticleUrl).overrideWithValue(
-          Future.value(
-            MockMetadata(
-              imageUrl: testNewArticleImageUrl,
-            ),
-          ),
+        ogpImageUrlProviderFamily(testNewArticleUrl).overrideWith(
+          (ref) => testNewArticleImageUrl,
         ),
-        metadataProviderFamily(testOldArticleUrl).overrideWithValue(
-          Future.value(
-            MockMetadata(
-              imageUrl: testOldArticleImageUrl,
-            ),
-          ),
+        ogpImageUrlProviderFamily(testOldArticleUrl).overrideWith(
+          (ref) => testOldArticleImageUrl,
         ),
       ],
     );
@@ -298,19 +269,11 @@ void main() {
             ],
           ),
         ),
-        metadataProviderFamily(testNewArticleUrl).overrideWithValue(
-          Future.value(
-            MockMetadata(
-              imageUrl: testNewArticleImageUrl,
-            ),
-          ),
+        ogpImageUrlProviderFamily(testNewArticleUrl).overrideWith(
+          (ref) => testNewArticleImageUrl,
         ),
-        metadataProviderFamily(testOldArticleUrl).overrideWithValue(
-          Future.value(
-            MockMetadata(
-              imageUrl: testOldArticleImageUrl,
-            ),
-          ),
+        ogpImageUrlProviderFamily(testOldArticleUrl).overrideWith(
+          (ref) => testOldArticleImageUrl,
         ),
         rfc822ParserProvider.overrideWithValue(
           (_) => testFeedUpdatedAt,

--- a/test/feature/feed/feed_repository_test.dart
+++ b/test/feature/feed/feed_repository_test.dart
@@ -308,7 +308,7 @@ void main() {
 
   test('最終取得日時がない場合のテスト', () {
     final container = ProviderContainer();
-    final isNewChecker = container.read(isNewCheckerProvider);
+    final isNewChecker = container.read(feedRepositoryProvider).checkIsNew;
 
     expect(
       isNewChecker(
@@ -349,7 +349,7 @@ void main() {
 
   test('最終取得日時があるときのテスト', () {
     final container = ProviderContainer();
-    final isNewChecker = container.read(isNewCheckerProvider);
+    final isNewChecker = container.read(feedRepositoryProvider).checkIsNew;
     final lastUpdatedAt = DateTime(2021, 1, 1);
 
     expect(


### PR DESCRIPTION
- [♻️OGP画像取得周りをリファクタ](https://github.com/K9i-0/flutter_feed_viewer/pull/11/commits/5ed5fbc82de081764f4c50fd4eadc9736df74e55)
  - シンプルにimageを取得するように変更
- [♻️新着判定をリポジトリのメソッドに変更](https://github.com/K9i-0/flutter_feed_viewer/pull/11/commits/9cfc917a95bacd9674344c07830020c8fb6729a3)
  - テストするために切り出していたが、汎用的な処理ではないのでvisibleForTestingをつけてリポジトリのメソッドに変更